### PR TITLE
Fix for unlisted videos with 2 parameters for ID

### DIFF
--- a/lite-vimeo-embed.js
+++ b/lite-vimeo-embed.js
@@ -83,7 +83,7 @@ style.textContent = /*css*/`
  *   https://github.com/Daugilas/lazyYT
  *   https://github.com/vb/lazyframe
  */
-class LiteVimeo extends (globalThis.HTMLElement ?? class {}) {
+class LiteVimeo extends (globalThis.HTMLElement ?? class { }) {
   /**
    * Begin pre-connecting to warm up the iframe load
    * Since the embed's network requests load within its iframe,
@@ -164,7 +164,11 @@ class LiteVimeo extends (globalThis.HTMLElement ?? class {}) {
     iframeEl.allow = 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture';
     // AFAIK, the encoding here isn't necessary for XSS, but we'll do it only because this is a URL
     // https://stackoverflow.com/q/64959723/89484
-    iframeEl.src = `https://player.vimeo.com/video/${encodeURIComponent(this.videoId)}?autoplay=1`;
+
+    // Check if is a unlisted video with two part videoId
+    const encodedVideoId = this.videoId.includes('/') ? this.videoId.split('/').map(encodeURIComponent).join('?h=') : encodeURIComponent(input);
+
+    iframeEl.src = `https://player.vimeo.com/video/${encodedVideoId}?autoplay=1`;
     this.append(iframeEl);
 
     // Set focus for a11y


### PR DESCRIPTION
There are videos on Vimeo that are with 2 parameters in the URL.

These are "Unlisted" videos (Available on Plus and higher plans), that has the video ID, a slash and then a privacy hash.

More info:
https://www.denisbouquet.com/vimeo-url-2-strings-unlisted-hash-videos-with-2-ids/

I changed the script in order to detect if the parameter has a "/" (slash) in it, and split the two parameters, then join them as follows: "_parameter1_?h=_parameter2_", encoding each parameter, or... if it has only one parameter, continue as before, encoding the single parameter.